### PR TITLE
Repository Mute Filters

### DIFF
--- a/src/js/Actions/Repositories.ts
+++ b/src/js/Actions/Repositories.ts
@@ -1,0 +1,12 @@
+import ActionConstants from 'Constants/Actions/Index';
+
+/**
+ * @param  {IGitHubRepository} repository
+ */
+export function addRepository(repository: IGitHubRepository)
+{
+  return {
+    type       : ActionConstants.repositories.ADD_REPOSITORY,
+    repository
+  };
+};

--- a/src/js/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/RepositoryMuteFilters.ts
@@ -36,3 +36,12 @@ export function setSubjectFilter(accountId: number,
     enabled
   };
 };
+
+export function removeFilter(accountId: number, repoId: string)
+{
+  return {
+    type      : ActionConstants.repositoryMuteFilters.REMOVE_FILTER,
+    accountId,
+    repoId
+  };
+};

--- a/src/js/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/RepositoryMuteFilters.ts
@@ -1,0 +1,10 @@
+import ActionConstants from 'Constants/Actions/Index';
+
+export function setupRepositoryMuteFilter(accountId: number, repositoryId: string)
+{
+  return {
+    type         : ActionConstants.repositoryMuteFilters.SETUP_FILTER,
+    accountId,
+    repositoryId
+  };
+};

--- a/src/js/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/RepositoryMuteFilters.ts
@@ -8,3 +8,31 @@ export function setupRepositoryMuteFilter(accountId: number, repositoryId: strin
     repositoryId
   };
 };
+
+export function setReasonFilter(accountId: number,
+                                repoId: string,
+                                filterName: string,
+                                enabled: boolean)
+{
+  return {
+    type       : ActionConstants.repositoryMuteFilters.SET_REASON_FILTER,
+    accountId,
+    repoId,
+    filterName,
+    enabled
+  };
+};
+
+export function setSubjectFilter(accountId: number,
+                                 repoId: string,
+                                 filterName: string,
+                                 enabled: boolean)
+{
+  return {
+    type       : ActionConstants.repositoryMuteFilters.SET_SUBJECT_FILTER,
+    accountId,
+    repoId,
+    filterName,
+    enabled
+  };
+};

--- a/src/js/Actions/UIActions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/UIActions/RepositoryMuteFilters.ts
@@ -1,0 +1,53 @@
+import * as get from 'lodash/lodash';
+import { push } from 'react-router-redux';
+
+import { getState } from 'Helpers/State/Store';
+
+import { addRepository } from 'Actions/Repositories';
+import { setupRepositoryMuteFilter as setupRepositoryMuteFilterInStore } from 'Actions/RepositoryMuteFilters';
+
+/**
+ * @param  {number} accountId
+ * @param  {IGitHubRepository} repository
+ * @param  {string=null} redirect
+ */
+export function setupRepositoryMuteFilter(accountId: number,
+                                          repository: IGitHubRepository,
+                                          redirect: string = null)
+{
+  return dispatch =>
+  {
+    let canRedirect = typeof redirect === 'string';
+
+    let state          = getState<IState>();
+    let existingFilter = get(state.repositoryMuteFilters, `${accountId}.${repository.id}`, undefined);
+
+    /*
+     * If we have an existing filter than go no further.
+     * Although redirect if one has been set.
+     */
+    if (typeof existingFilter !== 'undefined') {
+      if (canRedirect) {
+        push(redirect);
+      }
+
+      return;
+    }
+
+    /*
+     * Store the repository in state, and setup the default filters
+     */
+    dispatch(addRepository(repository));
+    dispatch(setupRepositoryMuteFilterInStore(accountId, repository.id.toString()));
+
+    /*
+     * Make sure we've let things setup, then redirect
+     */
+    setTimeout(() =>
+    {
+      if (canRedirect) {
+        push(redirect);
+      }
+    }, 0);
+  };
+};

--- a/src/js/Actions/UIActions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/UIActions/RepositoryMuteFilters.ts
@@ -4,7 +4,10 @@ import { push } from 'react-router-redux';
 import { getState } from 'Helpers/State/Store';
 
 import { addRepository } from 'Actions/Repositories';
-import { setupRepositoryMuteFilter as setupRepositoryMuteFilterInStore } from 'Actions/RepositoryMuteFilters';
+import {
+  removeFilter,
+  setupRepositoryMuteFilter as setupRepositoryMuteFilterInStore
+} from 'Actions/RepositoryMuteFilters';
 
 /**
  * @param  {number} accountId
@@ -51,5 +54,47 @@ export function setupRepositoryMuteFilter(accountId: number,
 
       dispatch(push(redirect));
     }, 0);
+  };
+};
+
+/**
+ * @param  {number} accountId
+ * @param  {string} repoId
+ * @param  {string=null} redirect
+ */
+export function removeRepositoryMuteFilter(accountId: number,
+                                           repoId: string,
+                                           redirect: string = null)
+{
+  return dispatch =>
+  {
+    let canRedirect = typeof redirect === 'string';
+
+    let state          = getState<IState>();
+    let existingFilter = get(state.repositoryMuteFilters, `${accountId}.${repoId}`, undefined);
+
+    /*
+     * If there is no filter to delete, then attempt redirect
+     */
+    if (typeof existingFilter === 'undefined') {
+      if (canRedirect) {
+        dispatch(push(redirect));
+      }
+
+      return;
+    }
+
+    /*
+     * First attempt the redirect, to make sure
+     * we're not on the page.
+     */
+    if (canRedirect) {
+      dispatch(push(redirect));
+    }
+
+    /*
+     * Remove the filter
+     */
+    dispatch(removeFilter(accountId, repoId));
   };
 };

--- a/src/js/Actions/UIActions/RepositoryMuteFilters.ts
+++ b/src/js/Actions/UIActions/RepositoryMuteFilters.ts
@@ -1,4 +1,4 @@
-import * as get from 'lodash/lodash';
+import * as get from 'lodash/get';
 import { push } from 'react-router-redux';
 
 import { getState } from 'Helpers/State/Store';
@@ -28,7 +28,7 @@ export function setupRepositoryMuteFilter(accountId: number,
      */
     if (typeof existingFilter !== 'undefined') {
       if (canRedirect) {
-        push(redirect);
+        dispatch(push(redirect));
       }
 
       return;
@@ -45,9 +45,11 @@ export function setupRepositoryMuteFilter(accountId: number,
      */
     setTimeout(() =>
     {
-      if (canRedirect) {
-        push(redirect);
+      if (!canRedirect) {
+        return;
       }
+
+      dispatch(push(redirect));
     }, 0);
   };
 };

--- a/src/js/Constants/Actions/Index.ts
+++ b/src/js/Constants/Actions/Index.ts
@@ -6,16 +6,20 @@ import AuthenticationActions from './Authentication';
 import AppAlertsActions from './AppAlerts';
 import SetupActions from './Setup';
 import NotificationFilterActions from './NotificationFilter';
+import RepositoryActions from './Repositories';
+import RepositoryMuteFilterActions from './RepositoryMuteFilters';
 
 const ActionConstants = {
-  accounts           : AccountsActions,
-  app                : AppActions,
-  notifications      : NotificationsActions,
-  settings           : SettingsActions,
-  authentication     : AuthenticationActions,
-  appAlerts          : AppAlertsActions,
-  setup              : SetupActions,
-  notificationFilter : NotificationFilterActions
+  accounts              : AccountsActions,
+  app                   : AppActions,
+  notifications         : NotificationsActions,
+  settings              : SettingsActions,
+  authentication        : AuthenticationActions,
+  appAlerts             : AppAlertsActions,
+  setup                 : SetupActions,
+  notificationFilter    : NotificationFilterActions,
+  repositories          : RepositoryActions,
+  repositoryMuteFilters : RepositoryMuteFilterActions
 };
 
 export default ActionConstants;

--- a/src/js/Constants/Actions/Repositories.ts
+++ b/src/js/Constants/Actions/Repositories.ts
@@ -1,0 +1,6 @@
+
+const RepositoryActions = {
+
+};
+
+export default RepositoryActions;

--- a/src/js/Constants/Actions/Repositories.ts
+++ b/src/js/Constants/Actions/Repositories.ts
@@ -1,6 +1,6 @@
 
 const RepositoryActions = {
-
+  ADD_REPOSITORY : 'ADD_REPOSITORY'
 };
 
 export default RepositoryActions;

--- a/src/js/Constants/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Constants/Actions/RepositoryMuteFilters.ts
@@ -2,7 +2,8 @@
 const RepositoryMuteFilterActions = {
   SETUP_FILTER       : 'SETUP_FILTER',
   SET_REASON_FILTER  : 'SET_REASON_FILTER',
-  SET_SUBJECT_FILTER : 'SET_SUBJECT_FILTER'
+  SET_SUBJECT_FILTER : 'SET_SUBJECT_FILTER',
+  REMOVE_FILTER      : 'REMOVE_FILTER'
 };
 
 export default RepositoryMuteFilterActions;

--- a/src/js/Constants/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Constants/Actions/RepositoryMuteFilters.ts
@@ -1,6 +1,8 @@
 
 const RepositoryMuteFilterActions = {
-  SETUP_FILTER : 'SETUP_FILTER'
+  SETUP_FILTER       : 'SETUP_FILTER',
+  SET_REASON_FILTER  : 'SET_REASON_FILTER',
+  SET_SUBJECT_FILTER : 'SET_SUBJECT_FILTER'
 };
 
 export default RepositoryMuteFilterActions;

--- a/src/js/Constants/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Constants/Actions/RepositoryMuteFilters.ts
@@ -1,6 +1,6 @@
 
 const RepositoryMuteFilterActions = {
-
+  SETUP_FILTER : 'SETUP_FILTER'
 };
 
 export default RepositoryMuteFilterActions;

--- a/src/js/Constants/Actions/RepositoryMuteFilters.ts
+++ b/src/js/Constants/Actions/RepositoryMuteFilters.ts
@@ -1,0 +1,6 @@
+
+const RepositoryMuteFilterActions = {
+
+};
+
+export default RepositoryMuteFilterActions;

--- a/src/js/Constants/Services/GitHub.ts
+++ b/src/js/Constants/Services/GitHub.ts
@@ -53,12 +53,12 @@ export const gitHubNotificationReasonTypes = {
 };
 
 export const gitHubNotificationReasonTypePrettyNames = {
-  SUBSCRIBED : 'Subscribed',
-  MANUAL : 'Manual',
-  AUTHOR : 'Authored',
-  COMMENT : 'Commented',
-  MENTION : 'Mentioned',
+  SUBSCRIBED  : 'Watching',
+  MANUAL      : 'Watching Thread',
+  AUTHOR      : 'Authored',
+  COMMENT     : 'Commented',
+  MENTION     : 'Mentioned',
   TEAMMENTION : 'Team Mention',
   STATECHANGE : 'State Changed',
-  ASSIGN : 'Assigned'
+  ASSIGN      : 'Assigned'
 };

--- a/src/js/Constants/State/RepositoryMuteFilters.ts
+++ b/src/js/Constants/State/RepositoryMuteFilters.ts
@@ -1,0 +1,9 @@
+import {
+  gitHubNotificationReasonTypes,
+  githubNotificationSubjectTypes
+} from 'Constants/Services/GitHub';
+
+export const defaultRepositoryMuteFilter: IStateRepositoryMuteFiltersAccountRepo = {
+  allowedSubjectTypes : Object.keys(githubNotificationSubjectTypes),
+  allowReasons        : Object.keys(gitHubNotificationReasonTypes)
+};

--- a/src/js/Constants/State/RepositoryMuteFilters.ts
+++ b/src/js/Constants/State/RepositoryMuteFilters.ts
@@ -5,5 +5,5 @@ import {
 
 export const defaultRepositoryMuteFilter: IStateRepositoryMuteFiltersAccountRepo = {
   allowedSubjectTypes : Object.keys(githubNotificationSubjectTypes),
-  allowReasons        : Object.keys(gitHubNotificationReasonTypes)
+  allowedReasons      : Object.keys(gitHubNotificationReasonTypes)
 };

--- a/src/js/Electron/Dialogs/Accounts.ts
+++ b/src/js/Electron/Dialogs/Accounts.ts
@@ -8,6 +8,7 @@ import { createSuccessAppAlert } from 'Helpers/Models/AppAlert';
 import { pushAppAlert } from 'Actions/AppAlerts';
 import { removeAccount } from 'Actions/UIActions/Accounts';
 import { removeAccountsNotifications } from 'Actions/Notifications';
+import { removeRepositoryMuteFilter } from 'Actions/UIActions/RepositoryMuteFilters';
 
 /**
  * @param  {string} accountId
@@ -67,4 +68,34 @@ export function confirmClearNotifications(accountId: number)
       'Accounts notifications have been removed.'
     )));
   });
+};
+
+/**
+ * @param  {number} accountId
+ * @param  {string} repoId
+ * @param  {string=null} redirect
+ */
+export function confirmRemoveRepositoryMuteFilter(accountId: number,
+                                                  repoId: string,
+                                                  redirect: string = null)
+{
+  getElectron().remote.dialog.showMessageBox(getCurrentWindow(), {
+    type    : 'question',
+    title   : 'Are you sure?',
+    message : 'Are you sure you want to remove this repositories Mute Filter?',
+    buttons : [
+      'Yes',
+      'No'
+    ]
+  }, index =>
+  {
+    if (index === 1) {
+      return;
+    }
+
+    dispatch(removeRepositoryMuteFilter(accountId, repoId, redirect));
+    dispatch(pushAppAlert(createSuccessAppAlert(
+      'Repository Mute Filter removed'
+    )));
+  })
 };

--- a/src/js/Electron/Menus/Repository.ts
+++ b/src/js/Electron/Menus/Repository.ts
@@ -1,0 +1,26 @@
+import {
+  getNewRemoteElectronMenu,
+  getNewRemoteElectronMenuItem
+} from 'Helpers/System/Electron';
+import { dispatch } from 'Helpers/State/Store';
+
+import { setupRepositoryMuteFilter } from 'Actions/UIActions/RepositoryMuteFilters';
+
+export default function createMenu(accountId: number, repository: IGitHubRepository): Electron.Menu
+{
+  let menu = getNewRemoteElectronMenu();
+
+  menu.append(getNewRemoteElectronMenuItem({
+    label : 'Setup Mute Filter',
+    click : () => dispatch(setupRepositoryMuteFilter(
+      accountId,
+      repository,
+      'settings/accounts/'
+        + accountId
+        + '/repo-mute-filter/'
+        + repository.id
+    ))
+  }));
+
+  return menu;
+};

--- a/src/js/Electron/Menus/Repository.ts
+++ b/src/js/Electron/Menus/Repository.ts
@@ -11,7 +11,7 @@ export default function createMenu(accountId: number, repository: IGitHubReposit
   let menu = getNewRemoteElectronMenu();
 
   menu.append(getNewRemoteElectronMenuItem({
-    label : 'Setup Mute Filter',
+    label : 'Create Mute Filter',
     click : () => dispatch(setupRepositoryMuteFilter(
       accountId,
       repository,

--- a/src/js/Electron/Menus/Repository.ts
+++ b/src/js/Electron/Menus/Repository.ts
@@ -11,7 +11,7 @@ export default function createMenu(accountId: number, repository: IGitHubReposit
   let menu = getNewRemoteElectronMenu();
 
   menu.append(getNewRemoteElectronMenuItem({
-    label : 'Create Mute Filter',
+    label : 'Edit Mute Filter',
     click : () => dispatch(setupRepositoryMuteFilter(
       accountId,
       repository,

--- a/src/js/Helpers/Lang/Array.ts
+++ b/src/js/Helpers/Lang/Array.ts
@@ -14,6 +14,40 @@ export function getLast<T>(array: T[]): T
 
 /**
  * @param  {any[]} array
+ */
+export function hasItems(array: any[])
+{
+  return array.length > 0;
+}
+
+/**
+ * @param  {any[]} array
+ * @param  {number} min
+ */
+export function hasMinItems(array: any[], min: number)
+{
+  return array.length > min;
+};
+
+/**
+ * @param  {number} index
+ */
+export function isFirstItem(index: number)
+{
+  return index === 0;
+};
+
+/**
+ * @param  {any[]} array
+ * @param  {number} index
+ */
+export function isLastItem(array: any[], index: number)
+{
+  return array.length === index + 1;
+};
+
+/**
+ * @param  {any[]} array
  * @param  {(key:any)=>any} getValue
  * @returns any
  */

--- a/src/js/Helpers/Models/GitHubNotification.ts
+++ b/src/js/Helpers/Models/GitHubNotification.ts
@@ -105,6 +105,9 @@ export function muteFilterNotifications(notifications: IGitHubNotification[],
         {
           let muteFilter    = muteFilters[repoIdToFilter];
           let notifications = repoSplit[repoIdToFilter];
+          if (typeof notifications === 'undefined') {
+            return;
+          }
 
           /*
            * Create the FilterSet with the rules

--- a/src/js/Helpers/Models/GitHubNotification.ts
+++ b/src/js/Helpers/Models/GitHubNotification.ts
@@ -1,3 +1,5 @@
+import * as concat from 'lodash/concat';
+
 import { getAccountToken } from './Accounts';
 import { makeGitHubRepository } from './GitHubRepository';
 
@@ -75,3 +77,82 @@ export function markNotificationsAsRead(accountId: number,
   let nIds = notifications.map(n => n.id.toString());
   markMultipleNotificationsAsRead(token, accountId, nIds);
 };
+
+export function muteFilterNotifications(notifications: IGitHubNotification[],
+                                        muteFilters: IStateRepositoryMuteFiltersAccount): IGitHubNotification[]
+{
+  /*
+   * Split notifications by repository
+   */
+  let repoSplit            = splitNotificationsByRepository(notifications);
+  let notificationsToGroup = [];
+
+  /*
+   * Go through the splits, any repos
+   * with no muteFilters, add to the group
+   */
+  Object.keys(repoSplit)
+        .forEach(repoId => typeof muteFilters[repoId] === 'undefined'
+                              ? notificationsToGroup.push(repoSplit[repoId])
+                              : undefined);
+
+  /*
+   * Now go through the muteFilters, and
+   * filter each set of notifications down
+   */
+  Object.keys(muteFilters)
+        .forEach(repoIdToFilter =>
+        {
+          let muteFilter    = muteFilters[repoIdToFilter];
+          let notifications = repoSplit[repoIdToFilter];
+
+          /*
+           * Create the FilterSet with the rules
+           * from the Repository Mute Filter.
+           *
+           * Even though read and repository is set here,
+           * they will not be filtered for.
+           */
+          let filterSet: INotificationFilterSet = {
+            read        : true,
+            subjectType : muteFilter.allowedSubjectTypes,
+            reasonType  : muteFilter.allowedReasons,
+            repository  : []
+          };
+
+          /*
+           * Filter down the notifications by Subject and Reason,
+           * then chuck the filtered notifications in to the group
+           */
+          notifications = (new Filter<IGitHubNotification>(notifications, filterSet)
+                            .addFilterFunctions(Subject, Reason)
+                            .filter());
+
+          notificationsToGroup.push(notifications);
+        });
+
+  /*
+   * Concat all notifications in to a single array
+   */
+  return concat(...notificationsToGroup);
+};
+
+/**
+ * @param  {IGitHubNotification[]} notifications
+ * @returns IGitHubNotification
+ */
+export function splitNotificationsByRepository(notifications: IGitHubNotification[]): { [repositoryId: string]: IGitHubNotification[] }
+{
+  let repos = {};
+
+  notifications.forEach(n =>
+  {
+    if (typeof repos[n.repository.id] === 'undefined') {
+      repos[n.repository.id] = [];
+    }
+
+    repos[n.repository.id].push(n);
+  })
+
+  return repos;
+}

--- a/src/js/Helpers/Models/RepositoryMuteFilters.ts
+++ b/src/js/Helpers/Models/RepositoryMuteFilters.ts
@@ -1,0 +1,10 @@
+import { getState } from 'Helpers/State/Store';
+
+/**
+ * @param  {number} accountId
+ * @returns IStateRepositoryMuteFiltersAccount
+ */
+export function getAccountRepositoryMuteFilters(accountId: string): IStateRepositoryMuteFiltersAccount
+{
+  return getState<IState>().repositoryMuteFilters[accountId] || {};
+};

--- a/src/js/Interfaces/IState/IState.ts
+++ b/src/js/Interfaces/IState/IState.ts
@@ -3,9 +3,11 @@
 ///<reference path="./IStateAccounts.ts" />
 ///<reference path="./IStateSettings.ts" />
 ///<reference path="./IStateAppAlerts.ts" />
+///<reference path="./IStateRepositories.ts" />
 ///<reference path="./IStateNotifications.ts" />
 ///<reference path="./IStateAuthentication.ts" />
 ///<reference path="./IStateNotificationFilters.ts" />
+///<reference path="./IStateRepositoryMuteFilters.ts" />
 
 interface IState
 {
@@ -19,9 +21,13 @@ interface IState
 
   appAlerts: IStateAppAlerts;
 
+  repositories: IStateRepositories;
+
   notifications: IStateNotifications;
 
   authentication: IStateAuthentication;
 
   notificationFilters: IStateNotificationFilters;
+
+  repositoryMuteFilters: IStateRepositoryMuteFilters;
 };

--- a/src/js/Interfaces/IState/IStateRepositories.ts
+++ b/src/js/Interfaces/IState/IStateRepositories.ts
@@ -1,0 +1,5 @@
+
+interface IStateRepositories
+{
+  [repoId: string]: IGitHubRepository;
+};

--- a/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
+++ b/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
@@ -1,0 +1,17 @@
+
+interface IStateRepositoryMuteFilters
+{
+  [accountId: string]: IStateRepositoryMuteFiltersAccount;
+};
+
+interface IStateRepositoryMuteFiltersAccount
+{
+  [repoId: string]: IStateRepositoryMuteFiltersAccountRepo;
+};
+
+interface IStateRepositoryMuteFiltersAccountRepo
+{
+  allowedSubjectTypes: string[];
+
+  allowReasons: string[];
+};

--- a/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
+++ b/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
@@ -1,7 +1,7 @@
 
 interface IStateRepositoryMuteFilters
 {
-  [accountId: string]: IStateRepositoryMuteFiltersAccount;
+  [accountId: number]: IStateRepositoryMuteFiltersAccount;
 };
 
 interface IStateRepositoryMuteFiltersAccount

--- a/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
+++ b/src/js/Interfaces/IState/IStateRepositoryMuteFilters.ts
@@ -13,5 +13,5 @@ interface IStateRepositoryMuteFiltersAccountRepo
 {
   allowedSubjectTypes: string[];
 
-  allowReasons: string[];
+  allowedReasons: string[];
 };

--- a/src/js/Reducers/Index.ts
+++ b/src/js/Reducers/Index.ts
@@ -3,17 +3,21 @@ import Setup from './Setup';
 import Accounts from './Accounts';
 import Settings from './Settings';
 import AppAlerts from './AppAlerts';
+import Repositories from './Repositories';
 import Notifications from './Notifications';
 import Authentication from './Authentication';
 import NotificationFilters from './NotificationFilters';
+import RepositoryMuteFilters from './RepositoryMuteFilters';
 
 export default {
-  app                 : App,
-  setup               : Setup,
-  accounts            : Accounts,
-  settings            : Settings,
-  appAlerts           : AppAlerts,
-  notifications       : Notifications,
-  authentication      : Authentication,
-  notificationFilters : NotificationFilters
+  app                   : App,
+  setup                 : Setup,
+  accounts              : Accounts,
+  settings              : Settings,
+  appAlerts             : AppAlerts,
+  repositories          : Repositories,
+  notifications         : Notifications,
+  authentication        : Authentication,
+  notificationFilters   : NotificationFilters,
+  repositoryMuteFilters : RepositoryMuteFilters
 };

--- a/src/js/Reducers/Repositories.ts
+++ b/src/js/Reducers/Repositories.ts
@@ -9,7 +9,12 @@ const initialState: IStateRepositories = {
 };
 
 let reducingMethods = {
-
+  [ActionConstants.repositories.ADD_REPOSITORY] : (state: IStateRepositories, action: { repository: IGitHubRepository; }) =>
+  {
+    return objectAssign({}, state, {
+      [action.repository.id] : action.repository
+    });
+  }
 };
 
 export default Reducify(initialState, reducingMethods);

--- a/src/js/Reducers/Repositories.ts
+++ b/src/js/Reducers/Repositories.ts
@@ -1,0 +1,15 @@
+import Reducify from 'Helpers/State/Reducify';
+import ActionConstants from 'Constants/Actions/Index';
+
+import * as omit from 'lodash/omit';
+import * as objectAssign from 'object-assign';
+
+const initialState: IStateRepositories = {
+
+};
+
+let reducingMethods = {
+
+};
+
+export default Reducify(initialState, reducingMethods);

--- a/src/js/Reducers/RepositoryMuteFilters.ts
+++ b/src/js/Reducers/RepositoryMuteFilters.ts
@@ -1,6 +1,8 @@
 import Reducify from 'Helpers/State/Reducify';
 import ActionConstants from 'Constants/Actions/Index';
 
+import { defaultRepositoryMuteFilter } from 'Constants/State/RepositoryMuteFilters';
+
 import * as omit from 'lodash/omit';
 import * as objectAssign from 'object-assign';
 
@@ -9,7 +11,22 @@ const initialState: IStateRepositoryMuteFilters = {
 };
 
 let reducingMethods = {
+  [ActionConstants.repositoryMuteFilters.SETUP_FILTER] : (state: IStateRepositoryMuteFilters, action : { accountId: number;
+                                                                                                repositoryId: string; }) =>
+  {
+    let accountState = getAccountState(state, action.accountId);
 
+    return objectAssign({}, state, {
+      [action.accountId] : objectAssign({}, accountState, {
+        [action.repositoryId] : defaultRepositoryMuteFilter
+      })
+    });
+  }
+};
+
+function getAccountState(state: IStateRepositoryMuteFilters, accountId: number)
+{
+  return state[accountId] || {};
 };
 
 export default Reducify(initialState, reducingMethods);

--- a/src/js/Reducers/RepositoryMuteFilters.ts
+++ b/src/js/Reducers/RepositoryMuteFilters.ts
@@ -1,0 +1,15 @@
+import Reducify from 'Helpers/State/Reducify';
+import ActionConstants from 'Constants/Actions/Index';
+
+import * as omit from 'lodash/omit';
+import * as objectAssign from 'object-assign';
+
+const initialState: IStateRepositoryMuteFilters = {
+
+};
+
+let reducingMethods = {
+
+};
+
+export default Reducify(initialState, reducingMethods);

--- a/src/js/Reducers/RepositoryMuteFilters.ts
+++ b/src/js/Reducers/RepositoryMuteFilters.ts
@@ -4,6 +4,7 @@ import ActionConstants from 'Constants/Actions/Index';
 import { defaultRepositoryMuteFilter } from 'Constants/State/RepositoryMuteFilters';
 
 import * as omit from 'lodash/omit';
+import * as clone from 'lodash/clone';
 import * as objectAssign from 'object-assign';
 
 const initialState: IStateRepositoryMuteFilters = {
@@ -11,8 +12,9 @@ const initialState: IStateRepositoryMuteFilters = {
 };
 
 let reducingMethods = {
-  [ActionConstants.repositoryMuteFilters.SETUP_FILTER] : (state: IStateRepositoryMuteFilters, action : { accountId: number;
-                                                                                                repositoryId: string; }) =>
+  [ActionConstants.repositoryMuteFilters.SETUP_FILTER] : (state: IStateRepositoryMuteFilters,
+                                                          action : { accountId: number;
+                                                                     repositoryId: string; }) =>
   {
     let accountState = getAccountState(state, action.accountId);
 
@@ -21,12 +23,91 @@ let reducingMethods = {
         [action.repositoryId] : defaultRepositoryMuteFilter
       })
     });
+  },
+  [ActionConstants.repositoryMuteFilters.SET_REASON_FILTER] : (state: IStateRepositoryMuteFilters,
+                                                               action : { accountId: number;
+                                                                          repoId: string;
+                                                                          filterName: string;
+                                                                          enabled: boolean }) =>
+  {
+    let accountState = getAccountState(state, action.accountId);
+    let repoState    = getRepositoryState(accountState, action.repoId);
+    let filters      = clone(repoState.allowedReasons);
+
+    /*
+     * @todo: Clean this up
+     */
+    if (action.enabled
+          && filters.indexOf(action.filterName) === -1) {
+      filters.push(action.filterName);
+    }
+
+    if (!action.enabled
+          && filters.indexOf(action.filterName) > -1) {
+      filters = filters.filter(f => f !== action.filterName);
+    }
+
+    return objectAssign({}, state, {
+      [action.accountId] : objectAssign({}, accountState, {
+        [action.repoId] : objectAssign({}, repoState, {
+          allowReasons : filters
+        })
+      })
+    });
+  },
+  [ActionConstants.repositoryMuteFilters.SET_SUBJECT_FILTER] : (state: IStateRepositoryMuteFilters,
+                                                                action : { accountId: number;
+                                                                           repoId: string;
+                                                                           filterName: string;
+                                                                           enabled: boolean }) =>
+  {
+    let accountState = getAccountState(state, action.accountId);
+    let repoState    = getRepositoryState(accountState, action.repoId);
+    let filters      = clone(repoState.allowedSubjectTypes);
+
+    /*
+     * @todo: Clean this up
+     */
+    if (action.enabled
+          && filters.indexOf(action.filterName) === -1) {
+      filters.push(action.filterName);
+    }
+
+    if (!action.enabled
+          && filters.indexOf(action.filterName) > -1) {
+      filters = filters.filter(f => f !== action.filterName);
+    }
+
+    return objectAssign({}, state, {
+      [action.accountId] : objectAssign({}, accountState, {
+        [action.repoId] : objectAssign({}, repoState, {
+          allowedSubjectTypes : filters
+        })
+      })
+    })
   }
 };
 
-function getAccountState(state: IStateRepositoryMuteFilters, accountId: number)
+/**
+ * @param  {IStateRepositoryMuteFilters} state
+ * @param  {number} accountId
+ * @returns IStateRepositoryMuteFiltersAccount
+ */
+function getAccountState(state: IStateRepositoryMuteFilters,
+                         accountId: number): IStateRepositoryMuteFiltersAccount
 {
   return state[accountId] || {};
+};
+
+/**
+ * @param  {IStateRepositoryMuteFiltersAccount} accountState
+ * @param  {string} repoId
+ * @returns IStateRepositoryMuteFiltersAccountRepo
+ */
+function getRepositoryState(accountState: IStateRepositoryMuteFiltersAccount,
+                            repoId: string): IStateRepositoryMuteFiltersAccountRepo
+{
+  return accountState[repoId] || defaultRepositoryMuteFilter;
 };
 
 export default Reducify(initialState, reducingMethods);

--- a/src/js/Reducers/RepositoryMuteFilters.ts
+++ b/src/js/Reducers/RepositoryMuteFilters.ts
@@ -50,7 +50,7 @@ let reducingMethods = {
     return objectAssign({}, state, {
       [action.accountId] : objectAssign({}, accountState, {
         [action.repoId] : objectAssign({}, repoState, {
-          allowReasons : filters
+          allowedReasons : filters
         })
       })
     });

--- a/src/js/Reducers/RepositoryMuteFilters.ts
+++ b/src/js/Reducers/RepositoryMuteFilters.ts
@@ -85,6 +85,16 @@ let reducingMethods = {
         })
       })
     })
+  },
+  [ActionConstants.repositoryMuteFilters.REMOVE_FILTER] : (state: IStateRepositoryMuteFilters,
+                                                           action: { accountId: number;
+                                                                     repoId: string }) =>
+  {
+    let accountState = getAccountState(state, action.accountId);
+
+    return objectAssign({}, state, {
+      [action.accountId] : objectAssign({}, omit(accountState, action.repoId))
+    })
   }
 };
 

--- a/src/js/Routes.ts
+++ b/src/js/Routes.ts
@@ -3,6 +3,7 @@ import Index from 'View/Index';
 import SettingsIndex from 'View/Settings/Index';
 
 import SettingsAccountView from 'View/Settings/Accounts/View';
+import SettingsAccountRepositoryMuteFilter from 'View/Settings/Accounts/RepositoryMuteFilters';
 
 const routes: ReactRouter.PlainRoute[] = [{
     path      : 'settings',
@@ -10,6 +11,9 @@ const routes: ReactRouter.PlainRoute[] = [{
   }, {
     path      : 'settings/accounts/:accountId',
     component : SettingsAccountView
+  }, {
+    path      : 'settings/accounts/:accountId/repo-mute-filter/:repoId',
+    component : SettingsAccountRepositoryMuteFilter
   }
 ];
 

--- a/src/js/View/Components/GenericError.tsx
+++ b/src/js/View/Components/GenericError.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+
+import {
+  BtnTo,
+  CenteredBox
+} from 'View/Ui/Index';
+
+interface IGenericErrorProps
+{
+  title: string;
+
+  description: string;
+
+  buttonText: string;
+
+  buttonUrl: string;
+};
+
+class GenericError extends React.Component<IGenericErrorProps, any>
+{
+  render()
+  {
+    return (
+      <CenteredBox>
+        <h2 className="generic-error__title push-zeta--bottom">
+          {this.props.title}
+        </h2>
+        <p className="generic-error__description push-delta--bottom">
+          {this.props.description}
+        </p>
+        <BtnTo to={this.props.buttonUrl}
+               className="generic-error__btn max-width--200 push-auto--sides">
+          {this.props.buttonText}
+        </BtnTo>
+      </CenteredBox>
+    );
+  };
+};
+
+export default GenericError;

--- a/src/js/View/Components/NotificationFilters/Index.tsx
+++ b/src/js/View/Components/NotificationFilters/Index.tsx
@@ -123,6 +123,7 @@ class NotificationFilters extends React.Component<INotificationFiltersProps, any
             {filterSet.repositories.length > 0
               ? <NotificationFilterRepositoryFilter repositoryFilters={filterSet.repositories}
                                                     className="grid__item one-whole"
+                                                    accountId={this.props.accountId}
                                                     getTitle={() => 'Repositories'}
                                                     getFilterTitle={filter => filter.repository.fullName.toLowerCase()}
                                                     onClick={this.handleRepositoryFilterClick.bind(this)}

--- a/src/js/View/Components/NotificationFilters/NotificationFilterRepositoryFilter.tsx
+++ b/src/js/View/Components/NotificationFilters/NotificationFilterRepositoryFilter.tsx
@@ -1,9 +1,13 @@
 import * as React from 'react';
 
+import createMenu from 'Electron/Menus/Repository';
+
 import { Btn } from 'View/Ui/Index';
 
 interface INotificationFilterRepositoryFilterProps
 {
+  accountId: number;
+
   repositoryFilters: IGitHubNotificationFilterSetRepository[];
 
   className?: string;
@@ -19,6 +23,16 @@ interface INotificationFilterRepositoryFilterProps
 
 class NotificationFilterRepositoryFilter extends React.Component<INotificationFilterRepositoryFilterProps, any>
 {
+  handleRightClick(repository: IGitHubRepository, e)
+  {
+    e.preventDefault();
+
+    try {
+      createMenu(this.props.accountId, repository)
+        .popup(e.clientX, e.clientY);
+    } catch (e) {}
+  }
+
   render()
   {
     return (
@@ -35,7 +49,8 @@ class NotificationFilterRepositoryFilter extends React.Component<INotificationFi
                                   + (this.props.getFilterIsActive(filter)
                                        ? ' btn--active'
                                        : '')}
-                     onClick={this.props.onClick.bind(null, filter)}>
+                     onClick={this.props.onClick.bind(null, filter)}
+                     onContextMenu={this.handleRightClick.bind(this, filter.repository)}>
                   {this.props.getFilterTitle(filter)}
                   <span className="btn--pill__count">{filter.count}</span>
                 </Btn>

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -95,8 +95,9 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                 <Octicon name={this.props.repository.private
                                  ? 'lock'
                                  : 'repo'}
-                         className="display--inline text--betaw" />
-                <p className="display--inline text--delta push-zeta--left account-settings__repo">
+                         className={'display--inline position--relative top--nu '
+                                      + 'account-settings__repo-icon text--beta'} />
+                <p className="account-settings__repo display--inline text--delta push-zeta--left">
                   {this.props.repository.fullName}
                 </p>
               </div>
@@ -115,7 +116,9 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                            return (
                              <div key={type}
                                   className="grid__item one-whole push-delta--bottom">
-                               <label className="text--zeta push-zeta--bottom">{gitHubNotificationReasonTypePrettyNames[t]}</label>
+                               <label className="text--zeta push-zeta--bottom">
+                                 {gitHubNotificationReasonTypePrettyNames[t]}
+                               </label>
                                <Toggle options={[{
                                          index : 1,
                                          text  : 'Keep',

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+
+import { dispatch } from 'Helpers/State/Store';
+
+import ViewBar from 'View/Components/ViewBar/Index';
+import {
+  Btn,
+  Scroll
+} from 'View/Ui/Index';
+
+interface IAccountRepositoryMuteFilterProps extends ReactRouter.RouteComponentProps<{
+                                                      accountId: number;
+                                                      repoId: string;
+                                                    }, any>
+{
+
+};
+
+class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMuteFilterProps, any>
+{
+  render()
+  {
+    return (
+      <ViewBar title=""
+               backLink={'/settings/accounts/' + this.props.params.accountId}>
+        <Scroll>
+          {'Mute Filter settings'}
+        </Scroll>
+      </ViewBar>
+    );
+  }
+};
+
+export default connect(
+  (state: IState, props: IAccountRepositoryMuteFilterProps) => ({
+
+  })
+)(AccountRepositoryMuteFilter);

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -17,6 +17,8 @@ import {
   gitHubNotificationSubjectTypePrettyNames
 } from 'Constants/Services/GitHub';
 
+import { confirmRemoveRepositoryMuteFilter } from 'Electron/Dialogs/Accounts';
+
 import ViewBar from 'View/Components/ViewBar/Index';
 import {
   Btn,
@@ -53,6 +55,17 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                               enabled));
   }
 
+  handleRemoveRepositoryMuteFilter(e)
+  {
+    e.preventDefault();
+
+    confirmRemoveRepositoryMuteFilter(
+      this.props.params.accountId,
+      this.props.params.repoId,
+      '/settings/accounts/' + this.props.params.accountId
+    );
+  }
+
   render()
   {
     if (typeof this.props.repository === 'undefined'
@@ -68,7 +81,8 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                  <CenteredBox>
                    <a href="#"
                       className={'view-bar__settings__right-icon '
-                                  + 'view-bar__settings__right-icon--delete'}>
+                                  + 'view-bar__settings__right-icon--delete'}
+                      onClick={this.handleRemoveRepositoryMuteFilter.bind(this)}>
                      <Octicon name="x" />
                    </a>
                  </CenteredBox>

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -6,6 +6,11 @@ import * as Octicon from 'react-octicon';
 import { dispatch } from 'Helpers/State/Store';
 
 import {
+  setReasonFilter,
+  setSubjectFilter
+} from 'Actions/RepositoryMuteFilters';
+
+import {
   gitHubNotificationReasonTypes,
   githubNotificationSubjectTypes,
   gitHubNotificationReasonTypePrettyNames,
@@ -32,6 +37,22 @@ interface IAccountRepositoryMuteFilterProps extends ReactRouter.RouteComponentPr
 
 class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMuteFilterProps, any>
 {
+  handleReasonChange(reason: string, enabled: boolean)
+  {
+    dispatch(setReasonFilter(this.props.params.accountId,
+                             this.props.params.repoId,
+                             reason,
+                             enabled));
+  }
+
+  handleSubjectChange(subjectType: string, enabled: boolean)
+  {
+    dispatch(setSubjectFilter(this.props.params.accountId,
+                              this.props.params.repoId,
+                              subjectType,
+                              enabled));
+  }
+
   render()
   {
     if (typeof this.props.repository === 'undefined'
@@ -91,7 +112,7 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                                          value : false
                                        }]}
                                        value={this.props.repositoryMuteFilter.allowedReasons.indexOf(type) > -1}
-                                       onChange={val => { console.log(val); }} />
+                                       onChange={this.handleReasonChange.bind(this, type)} />
                              </div>
                            );
                          })}
@@ -121,7 +142,7 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                                          value : false
                                        }]}
                                        value={this.props.repositoryMuteFilter.allowedSubjectTypes.indexOf(type) > -1}
-                                       onChange={val => { console.log(val); }} />
+                                       onChange={this.handleSubjectChange.bind(this, type)} />
                              </div>
                            );
                          })}

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -1,12 +1,23 @@
 import * as React from 'react';
+import * as get from 'lodash/get';
 import { connect } from 'react-redux';
+import * as Octicon from 'react-octicon';
 
 import { dispatch } from 'Helpers/State/Store';
+
+import {
+  gitHubNotificationReasonTypes,
+  githubNotificationSubjectTypes,
+  gitHubNotificationReasonTypePrettyNames,
+  gitHubNotificationSubjectTypePrettyNames
+} from 'Constants/Services/GitHub';
 
 import ViewBar from 'View/Components/ViewBar/Index';
 import {
   Btn,
-  Scroll
+  Scroll,
+  Toggle,
+  CenteredBox,
 } from 'View/Ui/Index';
 
 interface IAccountRepositoryMuteFilterProps extends ReactRouter.RouteComponentProps<{
@@ -14,18 +25,110 @@ interface IAccountRepositoryMuteFilterProps extends ReactRouter.RouteComponentPr
                                                       repoId: string;
                                                     }, any>
 {
+  repository: IGitHubRepository;
 
+  repositoryMuteFilter: IStateRepositoryMuteFiltersAccountRepo;
 };
 
 class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMuteFilterProps, any>
 {
   render()
   {
+    if (typeof this.props.repository === 'undefined'
+          || typeof this.props.repositoryMuteFilter === 'undefined') {
+      return <p>Error!</p>;
+    }
+
     return (
-      <ViewBar title=""
-               backLink={'/settings/accounts/' + this.props.params.accountId}>
+      <ViewBar title={'Edit Mute Filter'}
+               backLink={'/settings/accounts/' + this.props.params.accountId}
+               getRightContent={() =>
+               (
+                 <CenteredBox>
+                   <a href="#"
+                      className={'view-bar__settings__right-icon '
+                                  + 'view-bar__settings__right-icon--delete'}>
+                     <Octicon name="x" />
+                   </a>
+                 </CenteredBox>
+               )}>
         <Scroll>
-          {'Mute Filter settings'}
+          <div className="grid account-settings-header">
+            <div className="grid__item one-quarter mobile-display--hidden"></div>
+            <div className="grid__item one-half mobile-one-whole">
+              <div className="soft-delta text--center truncate">
+                <Octicon name={this.props.repository.private
+                                 ? 'lock'
+                                 : 'repo'}
+                         className="display--inline text--betaw" />
+                <p className="display--inline text--delta push-zeta--left account-settings__repo">
+                  {this.props.repository.fullName}
+                </p>
+              </div>
+            </div>
+          </div>
+          <div className="soft-delta">
+            <div className="grid">
+              <div className="grid__item one-half mobile-one-whole">
+                <label className="push-delta--bottom">Reasons</label>
+                <div className="grid">
+                  {Object.keys(gitHubNotificationReasonTypes)
+                         .map(type =>
+                         {
+                           let t = gitHubNotificationReasonTypes[type];
+
+                           return (
+                             <div key={type}
+                                  className="grid__item one-whole push-delta--bottom">
+                               <label className="text--zeta push-zeta--bottom">{gitHubNotificationReasonTypePrettyNames[t]}</label>
+                               <Toggle options={[{
+                                         index : 1,
+                                         text  : 'Keep',
+                                         value : true
+                                       }, {
+                                         index : 2,
+                                         text  : 'Ignore',
+                                         value : false
+                                       }]}
+                                       value={this.props.repositoryMuteFilter.allowReasons.indexOf(type) > -1}
+                                       onChange={val => { console.log(val); }} />
+                             </div>
+                           );
+                         })}
+                </div>
+              </div>
+              <div className="grid__item one-half mobile-one-whole">
+                <label className="push-delta--bottom">Subject Types</label>
+                <div className="grid">
+                  {Object.keys(githubNotificationSubjectTypes)
+                         .map(type =>
+                         {
+                           let t = githubNotificationSubjectTypes[type];
+
+                           return (
+                             <div key={type}
+                                  className="grid__item one-whole push-delta--bottom">
+                               <label className="text--zeta push-zeta--bottom">
+                                 {gitHubNotificationSubjectTypePrettyNames[t]}
+                               </label>
+                               <Toggle options={[{
+                                         index : 1,
+                                         text  : 'Keep',
+                                         value : true
+                                       }, {
+                                         index : 2,
+                                         text  : 'Ignore',
+                                         value : false
+                                       }]}
+                                       value={this.props.repositoryMuteFilter.allowedSubjectTypes.indexOf(type) > -1}
+                                       onChange={val => { console.log(val); }} />
+                             </div>
+                           );
+                         })}
+                </div>
+              </div>
+            </div>
+          </div>
         </Scroll>
       </ViewBar>
     );
@@ -34,6 +137,9 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
 
 export default connect(
   (state: IState, props: IAccountRepositoryMuteFilterProps) => ({
-
+    repository           : state.repositories[props.params.repoId],
+    repositoryMuteFilter : get(state.repositoryMuteFilters,
+                               `${props.params.accountId}.${props.params.repoId}`,
+                               undefined)
   })
 )(AccountRepositoryMuteFilter);

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -90,7 +90,7 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
                                          text  : 'Ignore',
                                          value : false
                                        }]}
-                                       value={this.props.repositoryMuteFilter.allowReasons.indexOf(type) > -1}
+                                       value={this.props.repositoryMuteFilter.allowedReasons.indexOf(type) > -1}
                                        onChange={val => { console.log(val); }} />
                              </div>
                            );

--- a/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
+++ b/src/js/View/Settings/Accounts/RepositoryMuteFilters.tsx
@@ -19,13 +19,14 @@ import {
 
 import { confirmRemoveRepositoryMuteFilter } from 'Electron/Dialogs/Accounts';
 
-import ViewBar from 'View/Components/ViewBar/Index';
 import {
   Btn,
   Scroll,
   Toggle,
   CenteredBox,
 } from 'View/Ui/Index';
+import ViewBar from 'View/Components/ViewBar/Index';
+import GenericError from 'View/Components/GenericError';
 
 interface IAccountRepositoryMuteFilterProps extends ReactRouter.RouteComponentProps<{
                                                       accountId: number;
@@ -68,14 +69,28 @@ class AccountRepositoryMuteFilter extends React.Component<IAccountRepositoryMute
 
   render()
   {
+    let accountSettingsUrl = '/settings/accounts/' + this.props.params.accountId;
+
+    /*
+     * If we can't find the repository or mute
+     * filter, theres an issue.
+     */
     if (typeof this.props.repository === 'undefined'
           || typeof this.props.repositoryMuteFilter === 'undefined') {
-      return <p>Error!</p>;
+      return (
+        <ViewBar title="Edit Mute filter"
+                backLink={accountSettingsUrl}>
+          <GenericError title="Cannot find Repository Mute Filter"
+                        description="This Repository Mute Filter was not found."
+                        buttonText="Go Back"
+                        buttonUrl={accountSettingsUrl} />
+        </ViewBar>
+      )
     }
 
     return (
       <ViewBar title={'Edit Mute Filter'}
-               backLink={'/settings/accounts/' + this.props.params.accountId}
+               backLink={accountSettingsUrl}
                getRightContent={() =>
                (
                  <CenteredBox>

--- a/src/js/View/Settings/Accounts/View.tsx
+++ b/src/js/View/Settings/Accounts/View.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { push } from 'react-router-redux';
 
 import { dispatch } from 'Helpers/State/Store';
 import { getAccount } from 'Helpers/Models/Accounts';
@@ -13,18 +14,29 @@ import { updateAccount } from 'Actions/Accounts';
 import ViewBar from 'View/Components/ViewBar/Index';
 import {
   Btn,
-  Scroll
+  Scroll,
+  RoundedBtnSet
 } from 'View/Ui/Index';
 
 interface IViewAccountSettingsProps extends ReactRouter.RouteComponentProps<{
                                               accountId: string;
                                             }, any>
 {
+  repositories: IStateRepositories;
 
+  repositoryMuteFilters: IStateRepositoryMuteFiltersAccount;
 };
 
 class ViewAccountSettings extends React.Component<IViewAccountSettingsProps, any>
 {
+  handleRepositoryMuteFilterClick(repoId: string)
+  {
+    dispatch(push('/settings/accounts/'
+                  + this.props.params.accountId
+                  + '/repo-mute-filter/'
+                  + repoId));
+  }
+
   render()
   {
     let account = getAccount(this.props.params.accountId);
@@ -58,18 +70,46 @@ class ViewAccountSettings extends React.Component<IViewAccountSettingsProps, any
             <div className="grid">
               <div className="grid__item one-quarter mobile-display--hidden"></div>
               <div className="grid__item one-half mobile-one-whole">
-                <Btn className="settings-btn push-delta--bottom"
-                     onClick={() => dispatch(updateAccount(account.gitHubUser.id.toString(), true))}>
-                  {'Update Details'}
-                </Btn>
-                <Btn className="btn--error push-zeta--bottom"
-                     onClick={() => confirmClearNotifications(account.gitHubUser.id)}>
-                  {'Clear Notifications'}
-                </Btn>
-                <Btn className="btn--error"
-                     onClick={() => confirmRemoveAccount(this.props.params.accountId)}>
-                  Remove Account
-                </Btn>
+                <div className="grid">
+                  <div className="grid__item one-whole push-delta--bottom">
+                    <Btn className="settings-btn"
+                        onClick={() => dispatch(updateAccount(account.gitHubUser.id.toString(), true))}>
+                      {'Update Details'}
+                    </Btn>
+                  </div>
+                  {Object.keys(this.props.repositoryMuteFilters).length > 0
+                    ? (
+                        <div className="grid__item one-whole push-delta--bottom">
+                          <label className="text--zeta push-zeta--bottom">
+                            {'Repository Mute Filters'}
+                          </label>
+                          <RoundedBtnSet buttons={Object.keys(this.props.repositoryMuteFilters)
+                                                        .map(repoId =>
+                                                        {
+                                                          let repository = this.props.repositories[repoId];
+
+                                                          return {
+                                                            key       : repoId,
+                                                            text      : repository.fullName,
+                                                            className : 'settings-btn truncate soft-zeta--sides',
+                                                            onClick   : this.handleRepositoryMuteFilterClick.bind(this, repoId)
+                                                          };
+                                                        })} />
+                        </div>
+                      )
+                    : undefined}
+                  <div className="grid__item one-whole">
+                    <label className="text--zeta push-zeta--bottom">Danger Zone</label>
+                    <Btn className="btn--error push-zeta--bottom"
+                        onClick={() => confirmClearNotifications(account.gitHubUser.id)}>
+                      {'Clear Notifications'}
+                    </Btn>
+                    <Btn className="btn--error"
+                        onClick={() => confirmRemoveAccount(this.props.params.accountId)}>
+                      Remove Account
+                    </Btn>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -80,7 +120,8 @@ class ViewAccountSettings extends React.Component<IViewAccountSettingsProps, any
 };
 
 export default connect(
-  (state: IState) => ({
-
+  (state: IState, props: IViewAccountSettingsProps) => ({
+    repositories          : state.repositories,
+    repositoryMuteFilters : state.repositoryMuteFilters[props.params.accountId] || {}
   })
 )(ViewAccountSettings);

--- a/src/js/View/Ui/Index.ts
+++ b/src/js/View/Ui/Index.ts
@@ -9,6 +9,7 @@ import Toggle from './Toggle';
 import AppLoading from './AppLoading';
 import CenteredBox from './CenteredBox';
 import Notification from './Notification';
+import RoundedBtnSet from './RoundedBtnSet';
 import ProfilePicture from './ProfilePicture';
 
 export {
@@ -23,5 +24,6 @@ export {
   AppLoading,
   CenteredBox,
   Notification,
+  RoundedBtnSet,
   ProfilePicture
 };

--- a/src/js/View/Ui/RoundedBtnSet.tsx
+++ b/src/js/View/Ui/RoundedBtnSet.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import { Btn } from './Index';
+
+interface IRoundedBtnSetProps
+{
+  className?: string;
+
+  buttons: IRoundedBtnSetBtn[];
+};
+
+interface IRoundedBtnSetBtn
+{
+  key: string;
+
+  text: string;
+
+  className?: string;
+
+  onClick?();
+};
+
+class RoundedBtnSet extends React.Component<IRoundedBtnSetProps, any>
+{
+  render()
+  {
+    // @todo: Array helper methods to clean this array logic up
+    return (
+      <div className={this.props.className}>
+        {this.props.buttons
+             .map((btn, i, a) =>
+             {
+               let className = (btn.className || '')
+                                  + (a.length > 0
+                                        && i === 0
+                                        ? ' btn--hard-bottom'
+                                        : '')
+                                  + (a.length > 0
+                                        && i + 1 === a.length
+                                        ? ' btn--hard-top'
+                                        : '')
+                                  + (a.length > 0
+                                      && i !== 0
+                                      && i + 1 < a.length
+                                      ? ' btn--hard'
+                                      : '')
+
+               return (
+                 <Btn key={btn.key}
+                      className={className}
+                      onClick={btn.onClick}>
+                  {btn.text}
+                </Btn>
+               );
+             })}
+      </div>
+    );
+  }
+};
+
+export default RoundedBtnSet;

--- a/src/js/View/Ui/RoundedBtnSet.tsx
+++ b/src/js/View/Ui/RoundedBtnSet.tsx
@@ -31,15 +31,15 @@ class RoundedBtnSet extends React.Component<IRoundedBtnSetProps, any>
              .map((btn, i, a) =>
              {
                let className = (btn.className || '')
-                                  + (a.length > 0
+                                  + (a.length > 1
                                         && i === 0
                                         ? ' btn--hard-bottom'
                                         : '')
-                                  + (a.length > 0
+                                  + (a.length > 1
                                         && i + 1 === a.length
                                         ? ' btn--hard-top'
                                         : '')
-                                  + (a.length > 0
+                                  + (a.length > 1
                                       && i !== 0
                                       && i + 1 < a.length
                                       ? ' btn--hard'

--- a/src/js/View/Ui/RoundedBtnSet.tsx
+++ b/src/js/View/Ui/RoundedBtnSet.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
 
+import {
+  isLastItem,
+  hasMinItems,
+  isFirstItem
+} from 'Helpers/Lang/Array';
+
 import { Btn } from './Index';
 
 interface IRoundedBtnSetProps
@@ -24,24 +30,23 @@ class RoundedBtnSet extends React.Component<IRoundedBtnSetProps, any>
 {
   render()
   {
-    // @todo: Array helper methods to clean this array logic up
     return (
       <div className={this.props.className}>
         {this.props.buttons
              .map((btn, i, a) =>
              {
                let className = (btn.className || '')
-                                  + (a.length > 1
-                                        && i === 0
+                                  + (hasMinItems(a, 1)
+                                        && isFirstItem(i)
                                         ? ' btn--hard-bottom'
                                         : '')
-                                  + (a.length > 1
-                                        && i + 1 === a.length
+                                  + (hasMinItems(a, 1)
+                                        && isLastItem(a, i)
                                         ? ' btn--hard-top'
                                         : '')
-                                  + (a.length > 1
-                                      && i !== 0
-                                      && i + 1 < a.length
+                                  + (hasMinItems(a, 1)
+                                      && !isFirstItem(i)
+                                      && !isLastItem(a, i)
                                       ? ' btn--hard'
                                       : '')
 

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -94,6 +94,18 @@ label { color: #666; }
   }
 }
 
+.view-bar__settings__right-icon {
+  color: $text-color;
+
+  &:hover {
+    color: $brand-color-main;
+  }
+}
+
+.view-bar__settings__right-icon--delete:hover {
+  color: $background-error;
+}
+
 /*
  * Notifications
  */
@@ -171,7 +183,9 @@ label { color: #666; }
 }
 
 .account-settings__name,
-.account-settings__username {
+.account-settings__username,
+.account-settings__repo,
+.account-settings__repo-icon {
   color: $text-color;
 }
 

--- a/src/scss/themes/_dark.scss
+++ b/src/scss/themes/_dark.scss
@@ -232,3 +232,20 @@ label { color: #666; }
 .no-accounts__btn:hover {
   background: $button-bg-hover;
 }
+
+/*
+ * Generic Error
+ */
+.generic-error__title,
+.generic-error__description {
+  color: $text-color;
+}
+
+.generic-error__btn {
+  color: $text-color;
+  background: $button-bg;
+}
+
+.generic-error__btn:hover {
+  background: $button-bg-hover;
+}

--- a/src/scss/themes/_light.scss
+++ b/src/scss/themes/_light.scss
@@ -228,3 +228,20 @@ label { color: #666; }
 .no-accounts__btn:hover {
   background: $button-bg-hover;
 }
+
+/*
+ * Generic Error
+ */
+.generic-error__title,
+.generic-error__description {
+  color: $text-color;
+}
+
+.generic-error__btn {
+  color: $text-color;
+  background: $button-bg;
+}
+
+.generic-error__btn:hover {
+  background: $button-bg-hover;
+}

--- a/src/scss/themes/_light.scss
+++ b/src/scss/themes/_light.scss
@@ -90,6 +90,18 @@ label { color: #666; }
   }
 }
 
+.view-bar__settings__right-icon {
+  color: $text-color;
+
+  &:hover {
+    color: $brand-color-main;
+  }
+}
+
+.view-bar__settings__right-icon--delete:hover {
+  color: $background-error;
+}
+
 /*
  * Notifications
  */
@@ -167,7 +179,9 @@ label { color: #666; }
 }
 
 .account-settings__name,
-.account-settings__username {
+.account-settings__username,
+.account-settings__repo,
+.account-settings__repo-icon {
   color: $text-color;
 }
 


### PR DESCRIPTION
This PR implements per-account per-repository mute filters (#10). This enables users to mute a repositories notifications by Subject Type and Reason. To create or edit a mute filter for a repository, you right click on the repo in the filter list and hit Edit Mute Filter.

![image](https://cloud.githubusercontent.com/assets/1188830/21751251/2c5075c0-d5bc-11e6-8536-1305a5b4b9f8.png)

Clicking Edit Mute Filter will take you to the following window where you can switch off, or on, certain Reasons or Subject Types. You can also delete the mute filter entirely using the X on the top right. Keep will show you notifications for that Reason or Subject Type, whereas Ignore will remove them from your view.

![image](https://cloud.githubusercontent.com/assets/1188830/21751210/649fbc0c-d5bb-11e6-96d5-316beb83e4ae.png)

This PR also adds the following section to an accounts settings. Each button will take you to the page above, per repository.

![image](https://cloud.githubusercontent.com/assets/1188830/21751225/ac8a3484-d5bb-11e6-8b6e-bee59b4a3945.png)

Notifications that are muted are still ingested by Hawk Eye, but never shown to the user. This is so that if you decide to un-mute certain notifications they will become instantly available. The same goes for altering your mute filters, they will disappear when you edit your mute filter. Sounds will not be raised for notifications that have been muted.

The Settings design for this isn't the best it could be, by a long shot, but I think we can put in a separate PR to alter the structure of that.